### PR TITLE
Feature/scan command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(cyberpunk_lib STATIC
   src/model/gameModel.cpp
   src/controller/commandRegistry.cpp
   src/controller/helpCommand.cpp
+  src/controller/scanCommand.cpp
   src/controller/statusCommand.cpp
   src/controller/unknownCommand.cpp
 )
@@ -61,6 +62,7 @@ if(CYBERPUNK_BUILD_TESTS)
     tests/common/types_test.cpp
     tests/model/gameModel_test.cpp
     tests/controller/commandRegistry_test.cpp
+    tests/controller/scanCommand_test.cpp
   )
 
   target_include_directories(unit_tests PRIVATE

--- a/src/controller/commandRegistry.cpp
+++ b/src/controller/commandRegistry.cpp
@@ -2,6 +2,7 @@
 
 // Comandos del instructor — completos
 #include "helpCommand.hpp"
+#include "scanCommand.hpp"
 #include "statusCommand.hpp"
 #include "unknownCommand.hpp"
 
@@ -113,6 +114,7 @@ namespace CyberpunkCba
         // ZONA DE EQUIPOS — agregar una línea por equipo
         // Formato: registry.add(std::make_unique<TuComandoCommand>());
         // ============================================================
+        registry.add(std::make_unique<ScanCommand>());
 
         // ============================================================
         // FIN ZONA DE EQUIPOS

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -4,13 +4,34 @@
 #include "model/gameModel.hpp"
 
 #include <algorithm>
-#include <cassert>
 #include <iostream>
 #include <string>
 #include <vector>
 
 namespace CyberpunkCba
 {
+    namespace
+    {
+        AlertLevel alertLevelFromHostileCount(const int hostileCount) noexcept
+        {
+            if (hostileCount >= 4)
+            {
+                return AlertLevel::Maximum;
+            }
+
+            switch (hostileCount)
+            {
+            case 1:
+                return AlertLevel::Low;
+            case 2:
+                return AlertLevel::Medium;
+            case 3:
+                return AlertLevel::High;
+            default:
+                return AlertLevel::None;
+            }
+        }
+    } // namespace
 
     void ScanCommand::execute(GameModel& model)
     {
@@ -20,7 +41,6 @@ namespace CyberpunkCba
 
         for (const auto* pEntity : nearby)
         {
-            assert(pEntity != nullptr);
             if (pEntity == nullptr)
             {
                 continue;
@@ -47,15 +67,19 @@ namespace CyberpunkCba
             return;
         }
 
-        bool hasHostile {false};
+        int hostileCount {0};
         for (const auto* pEntity : sortedEntities)
         {
             std::cout << "[" << entityDispositionToString(pEntity->disposition) << "] " << pEntity->name << " - "
                       << pEntity->distanceMeters << " m\n";
-            hasHostile = hasHostile || pEntity->disposition == EntityDisposition::Hostile;
+            if (pEntity->disposition == EntityDisposition::Hostile)
+            {
+                ++hostileCount;
+            }
         }
 
-        if (hasHostile)
+        const auto targetLevel {alertLevelFromHostileCount(hostileCount)};
+        while (model.alertLevel() < targetLevel)
         {
             model.incrementAlert("Hostiles detectados durante escaneo de zona.");
         }

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -4,6 +4,7 @@
 #include "model/gameModel.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -18,6 +19,7 @@ namespace CyberpunkCba
 
         for (const auto* pEntity : nearby)
         {
+            assert(pEntity != nullptr);
             if (pEntity == nullptr)
             {
                 continue;

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -1,0 +1,79 @@
+#include "scanCommand.hpp"
+
+#include "common/types.hpp"
+#include "model/gameModel.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace CyberpunkCba
+{
+
+    void ScanCommand::execute(GameModel& model)
+    {
+        const auto& nearby {model.nearbyEntities()};
+        std::vector<const WorldEntity*> sortedEntities;
+        sortedEntities.reserve(nearby.size());
+
+        for (const auto* pEntity : nearby)
+        {
+            assert(pEntity != nullptr);
+            if (pEntity == nullptr)
+            {
+                continue;
+            }
+            sortedEntities.emplace_back(pEntity);
+        }
+
+        std::sort(sortedEntities.begin(),
+                  sortedEntities.end(),
+                  [](const WorldEntity* lhs, const WorldEntity* rhs)
+                  {
+                      if (lhs->distanceMeters == rhs->distanceMeters)
+                      {
+                          return lhs->name < rhs->name;
+                      }
+                      return lhs->distanceMeters < rhs->distanceMeters;
+                  });
+
+        std::cout << "Escaneo de zona: " << model.currentZone() << "\n";
+
+        if (sortedEntities.empty())
+        {
+            std::cout << "Sin entidades detectadas.\n";
+            return;
+        }
+
+        bool hasHostile {false};
+        for (const auto* pEntity : sortedEntities)
+        {
+            std::cout << "[" << entityDispositionToString(pEntity->disposition) << "] " << pEntity->name << " - "
+                      << pEntity->distanceMeters << " m\n";
+            hasHostile = hasHostile || pEntity->disposition == EntityDisposition::Hostile;
+        }
+
+        if (hasHostile)
+        {
+            model.incrementAlert("Hostiles detectados durante escaneo de zona.");
+        }
+    }
+
+    std::string ScanCommand::name() const
+    {
+        return "scan";
+    }
+
+    std::string ScanCommand::description() const
+    {
+        return "Escanea entidades cercanas en la zona.";
+    }
+
+    std::string ScanCommand::category() const
+    {
+        return "mundo";
+    }
+
+} // namespace CyberpunkCba

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -21,14 +21,10 @@ namespace CyberpunkCba
 
             switch (hostileCount)
             {
-                case 1:
-                    return AlertLevel::Low;
-                case 2:
-                    return AlertLevel::Medium;
-                case 3:
-                    return AlertLevel::High;
-                default:
-                    return AlertLevel::None;
+                case 1: return AlertLevel::Low;
+                case 2: return AlertLevel::Medium;
+                case 3: return AlertLevel::High;
+                default: return AlertLevel::None;
             }
         }
     } // namespace

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -10,25 +10,6 @@
 
 namespace CyberpunkCba
 {
-    namespace
-    {
-        AlertLevel alertLevelFromHostileCount(const int hostileCount) noexcept
-        {
-            if (hostileCount >= 4)
-            {
-                return AlertLevel::Maximum;
-            }
-
-            switch (hostileCount)
-            {
-                case 1: return AlertLevel::Low;
-                case 2: return AlertLevel::Medium;
-                case 3: return AlertLevel::High;
-                default: return AlertLevel::None;
-            }
-        }
-    } // namespace
-
     void ScanCommand::execute(GameModel& model)
     {
         const auto& nearby {model.nearbyEntities()};
@@ -74,7 +55,8 @@ namespace CyberpunkCba
             }
         }
 
-        const auto targetLevel {alertLevelFromHostileCount(hostileCount)};
+        const int capped {std::min(hostileCount, static_cast<int>(AlertLevel::Maximum))};
+        const auto targetLevel {static_cast<AlertLevel>(capped)};
         while (model.alertLevel() < targetLevel)
         {
             model.incrementAlert("Hostiles detectados durante escaneo de zona.");

--- a/src/controller/scanCommand.cpp
+++ b/src/controller/scanCommand.cpp
@@ -21,14 +21,14 @@ namespace CyberpunkCba
 
             switch (hostileCount)
             {
-            case 1:
-                return AlertLevel::Low;
-            case 2:
-                return AlertLevel::Medium;
-            case 3:
-                return AlertLevel::High;
-            default:
-                return AlertLevel::None;
+                case 1:
+                    return AlertLevel::Low;
+                case 2:
+                    return AlertLevel::Medium;
+                case 3:
+                    return AlertLevel::High;
+                default:
+                    return AlertLevel::None;
             }
         }
     } // namespace

--- a/src/controller/scanCommand.hpp
+++ b/src/controller/scanCommand.hpp
@@ -29,6 +29,7 @@ namespace CyberpunkCba
      * Lee entidades observadas desde GameModel::nearbyEntities(),
      * las ordena por distanceMeters ascendente y muestra salida compacta.
      * Si detecta al menos una entidad Hostile, incrementa la alerta del modelo.
+     * El nivel de alerta estará en función de la cantidad de Hostile.
      */
     class ScanCommand final : public Command
     {

--- a/src/controller/scanCommand.hpp
+++ b/src/controller/scanCommand.hpp
@@ -1,0 +1,26 @@
+#ifndef _SCAN_COMMAND_HPP
+#define _SCAN_COMMAND_HPP
+
+#include "controller/command.hpp"
+
+#include <string>
+
+namespace CyberpunkCba
+{
+
+    class ScanCommand final : public Command
+    {
+    public:
+        ScanCommand() = default;
+        ~ScanCommand() override = default;
+
+    private:
+        void execute(GameModel& model) override;
+        std::string name() const override;
+        std::string description() const override;
+        std::string category() const override;
+    };
+
+} // namespace CyberpunkCba
+
+#endif // _SCAN_COMMAND_HPP

--- a/src/controller/scanCommand.hpp
+++ b/src/controller/scanCommand.hpp
@@ -5,19 +5,60 @@
 
 #include <string>
 
+/**
+ * @file ScanCommand.hpp
+ * @brief Header privado de ScanCommand.
+ *
+ * @details
+ * Este header NO es parte de la API pública del sistema.
+ * Solo debe ser incluido por ScanCommand.cpp.
+ * La API pública es Command.hpp.
+ *
+ * @author Equipo 02 — Exodus Systems Inc.
+ * @version 0.1.0
+ */
+
 namespace CyberpunkCba
 {
 
+    /**
+     * @class ScanCommand
+     * @brief Escanea entidades cercanas en la zona actual.
+     *
+     * @details
+     * Lee entidades observadas desde GameModel::nearbyEntities(),
+     * las ordena por distanceMeters ascendente y muestra salida compacta.
+     * Si detecta al menos una entidad Hostile, incrementa la alerta del modelo.
+     */
     class ScanCommand final : public Command
     {
     public:
+        /// @brief Construye ScanCommand sin estado propio.
         ScanCommand() = default;
+
         ~ScanCommand() override = default;
 
     private:
+        // Wazuh convention: implementaciones de interfaz son private.
+
+        /**
+         * @brief Ejecuta el escaneo de la zona actual.
+         * @details
+         * - Toma punteros observadores desde nearbyEntities().
+         * - Verifica precondición de no nulos (assert + guard defensivo).
+         * - Ordena por distancia y muestra entidades en formato compacto.
+         * - Si hay Hostile, incrementa alertLevel con causa descriptiva.
+         * @param model Modelo de juego a consultar/modificar.
+         */
         void execute(GameModel& model) override;
+
+        /// @brief Nombre canónico del comando.
         std::string name() const override;
+
+        /// @brief Descripción breve para help.
         std::string description() const override;
+
+        /// @brief Categoría de help.
         std::string category() const override;
     };
 

--- a/src/controller/scanCommand.hpp
+++ b/src/controller/scanCommand.hpp
@@ -14,7 +14,7 @@
  * Solo debe ser incluido por ScanCommand.cpp.
  * La API pública es Command.hpp.
  *
- * @author Equipo 02 — Exodus Systems Inc.
+ * @author Equipo Now Hiring — Exodus Systems Inc.
  * @version 0.1.0
  */
 

--- a/tests/controller/scanCommand_test.cpp
+++ b/tests/controller/scanCommand_test.cpp
@@ -1,0 +1,115 @@
+#include "common/types.hpp"
+#include "scanCommand.hpp"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "model/gameModel.hpp"
+
+using namespace CyberpunkCba;
+
+class ScanCommandTest : public ::testing::Test
+{
+protected:
+    static void setNearbyEntities(GameModel& model, std::vector<WorldEntity> entities)
+    {
+        auto& nearby {const_cast<std::vector<const WorldEntity*>&>(model.nearbyEntities())};
+        nearby.clear();
+
+        m_testEntities = std::move(entities);
+        for (const auto& entity : m_testEntities)
+        {
+            nearby.emplace_back(&entity);
+        }
+    }
+
+    std::string captureOutput()
+    {
+        std::ostringstream oss;
+        std::streambuf* old {std::cout.rdbuf(oss.rdbuf())};
+        Command& commandRef {m_command};
+        commandRef.execute(m_model);
+        std::cout.rdbuf(old);
+        return oss.str();
+    }
+
+    GameModel m_model {"Ghost_47"};
+    ScanCommand m_command;
+    inline static std::vector<WorldEntity> m_testEntities;
+};
+
+TEST_F(ScanCommandTest, EntitiesAreSortedByDistance)
+{
+    setNearbyEntities(m_model,
+                      {{"Entidad lejana", EntityDisposition::Neutral, 120},
+                       {"Entidad cercana", EntityDisposition::Friendly, 15},
+                       {"Entidad media", EntityDisposition::Hostile, 40}});
+
+    const auto output {captureOutput()};
+    const auto idxNear {output.find("Entidad cercana")};
+    const auto idxMid {output.find("Entidad media")};
+    const auto idxFar {output.find("Entidad lejana")};
+
+    ASSERT_NE(idxNear, std::string::npos);
+    ASSERT_NE(idxMid, std::string::npos);
+    ASSERT_NE(idxFar, std::string::npos);
+    EXPECT_LT(idxNear, idxMid);
+    EXPECT_LT(idxMid, idxFar);
+}
+
+TEST_F(ScanCommandTest, HostileIncrementsAlert)
+{
+    setNearbyEntities(m_model, {{"Corporativo Militech", EntityDisposition::Hostile, 25}});
+    const auto before {m_model.alertLevel()};
+
+    captureOutput();
+
+    EXPECT_EQ(m_model.alertLevel(), incrementAlertLevel(before));
+    EXPECT_FALSE(m_model.lastAlertCause().empty());
+}
+
+TEST_F(ScanCommandTest, EmptyZoneDoesNotModifyModel)
+{
+    setNearbyEntities(m_model, {});
+    const auto beforeAlert {m_model.alertLevel()};
+    const auto beforeCause {m_model.lastAlertCause()};
+
+    const auto output {captureOutput()};
+
+    EXPECT_EQ(m_model.alertLevel(), beforeAlert);
+    EXPECT_EQ(m_model.lastAlertCause(), beforeCause);
+    EXPECT_NE(output.find("Sin entidades detectadas."), std::string::npos);
+}
+
+TEST_F(ScanCommandTest, OnlyFriendlyDoesNotIncrementAlert)
+{
+    setNearbyEntities(
+        m_model,
+        {{"Mercader aliado", EntityDisposition::Friendly, 18}, {"Netrunner amigo", EntityDisposition::Friendly, 42}});
+    const auto beforeAlert {m_model.alertLevel()};
+    const auto beforeCause {m_model.lastAlertCause()};
+
+    captureOutput();
+
+    EXPECT_EQ(m_model.alertLevel(), beforeAlert);
+    EXPECT_EQ(m_model.lastAlertCause(), beforeCause);
+}
+
+TEST_F(ScanCommandTest, OutputContainsEachDisposition)
+{
+    setNearbyEntities(m_model,
+                      {{"Aliado", EntityDisposition::Friendly, 10},
+                       {"Civil", EntityDisposition::Neutral, 20},
+                       {"Guardia", EntityDisposition::Hostile, 30}});
+
+    const auto output {captureOutput()};
+
+    EXPECT_NE(output.find("[AMIGABLE]"), std::string::npos);
+    EXPECT_NE(output.find("[NEUTRAL]"), std::string::npos);
+    EXPECT_NE(output.find("[HOSTIL]"), std::string::npos);
+}

--- a/tests/controller/scanCommand_test.cpp
+++ b/tests/controller/scanCommand_test.cpp
@@ -62,15 +62,16 @@ TEST_F(ScanCommandTest, EntitiesAreSortedByDistance)
     EXPECT_LT(idxMid, idxFar);
 }
 
-TEST_F(ScanCommandTest, HostileIncrementsAlert)
+TEST_F(ScanCommandTest, AlertDoesNotChangeWhenAlreadyAtExpectedLevel)
 {
     setNearbyEntities(m_model, {{"Corporativo Militech", EntityDisposition::Hostile, 25}});
     const auto before {m_model.alertLevel()};
+    const auto beforeCause {m_model.lastAlertCause()};
 
     captureOutput();
 
-    EXPECT_EQ(m_model.alertLevel(), incrementAlertLevel(before));
-    EXPECT_FALSE(m_model.lastAlertCause().empty());
+    EXPECT_EQ(m_model.alertLevel(), before);
+    EXPECT_EQ(m_model.lastAlertCause(), beforeCause);
 }
 
 TEST_F(ScanCommandTest, EmptyZoneDoesNotModifyModel)
@@ -112,4 +113,46 @@ TEST_F(ScanCommandTest, OutputContainsEachDisposition)
     EXPECT_NE(output.find("[AMIGABLE]"), std::string::npos);
     EXPECT_NE(output.find("[NEUTRAL]"), std::string::npos);
     EXPECT_NE(output.find("[HOSTIL]"), std::string::npos);
+}
+
+TEST_F(ScanCommandTest, ScanRaisesAlertUpToTargetByHostileCount)
+{
+    setNearbyEntities(m_model,
+                      {{"Hostile A", EntityDisposition::Hostile, 10},
+                       {"Hostile B", EntityDisposition::Hostile, 20},
+                       {"Hostile C", EntityDisposition::Hostile, 30}});
+
+    captureOutput();
+
+    EXPECT_EQ(m_model.alertLevel(), AlertLevel::High);
+    EXPECT_FALSE(m_model.lastAlertCause().empty());
+}
+
+TEST_F(ScanCommandTest, ScanSaturatesAtMaximumWhenHostilesAreFourOrMore)
+{
+    setNearbyEntities(m_model,
+                      {{"Hostile A", EntityDisposition::Hostile, 10},
+                       {"Hostile B", EntityDisposition::Hostile, 20},
+                       {"Hostile C", EntityDisposition::Hostile, 30},
+                       {"Hostile D", EntityDisposition::Hostile, 40},
+                       {"Hostile E", EntityDisposition::Hostile, 50}});
+
+    captureOutput();
+
+    EXPECT_EQ(m_model.alertLevel(), AlertLevel::Maximum);
+}
+
+TEST_F(ScanCommandTest, ScanDoesNotDecreaseAlertWhenHostileCountDrops)
+{
+    m_model.incrementAlert("Escalada previa");
+    m_model.incrementAlert("Escalada previa");
+    EXPECT_EQ(m_model.alertLevel(), AlertLevel::High);
+
+    setNearbyEntities(m_model, {{"Civil", EntityDisposition::Neutral, 15}});
+    const auto beforeCause {m_model.lastAlertCause()};
+
+    captureOutput();
+
+    EXPECT_EQ(m_model.alertLevel(), AlertLevel::High);
+    EXPECT_EQ(m_model.lastAlertCause(), beforeCause);
 }

--- a/tests/controller/scanCommand_test.cpp
+++ b/tests/controller/scanCommand_test.cpp
@@ -16,7 +16,7 @@ using namespace CyberpunkCba;
 class ScanCommandTest : public ::testing::Test
 {
 protected:
-    static void setNearbyEntities(GameModel& model, std::vector<WorldEntity> entities)
+    void setNearbyEntities(GameModel& model, std::vector<WorldEntity> entities)
     {
         auto& nearby {const_cast<std::vector<const WorldEntity*>&>(model.nearbyEntities())};
         nearby.clear();
@@ -30,17 +30,33 @@ protected:
 
     std::string captureOutput()
     {
+        struct CoutRedirectGuard
+        {
+            explicit CoutRedirectGuard(std::ostream& os, std::streambuf* newBuffer)
+                : m_stream(os)
+                , m_oldBuffer(os.rdbuf(newBuffer))
+            {
+            }
+
+            ~CoutRedirectGuard()
+            {
+                m_stream.rdbuf(m_oldBuffer);
+            }
+
+            std::ostream& m_stream;
+            std::streambuf* m_oldBuffer;
+        };
+
         std::ostringstream oss;
-        std::streambuf* old {std::cout.rdbuf(oss.rdbuf())};
+        CoutRedirectGuard guard {std::cout, oss.rdbuf()};
         Command& commandRef {m_command};
         commandRef.execute(m_model);
-        std::cout.rdbuf(old);
         return oss.str();
     }
 
     GameModel m_model {"Ghost_47"};
     ScanCommand m_command;
-    inline static std::vector<WorldEntity> m_testEntities;
+    std::vector<WorldEntity> m_testEntities;
 };
 
 TEST_F(ScanCommandTest, EntitiesAreSortedByDistance)


### PR DESCRIPTION
# Pull Request — CyberCba2077

## Tipo de cambio
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] Performance
- [ ] Build / CI
- [ ] Chore

---

## Issue / tarea relacionada
- Closes #89
- Related #98

---

## Resumen del cambio
Este PR implementa `ScanCommand` para escanear entidades cercanas, ordenarlas por distancia y modificar el estado de alerta en función de la cantidad de hostiles presentes. 
Además registra el comando en el registry y agrega 5 tests de aceptación para validar orden, alerta, zona vacía, caso amigables y formato de salida. Se añaden 3 test más para validar la sincronía entre el nivel de alerta y la cantidad de hostiles.

---

## Problema / motivación
Contexto
- Faltaba el comando `scan` del sprint que debía interactuar con `GameModel`.

Problema observado
- No existía comportamiento para listar entidades cercanas ni para incrementar alerta ante hostiles.

Resultado esperado
- Poder ejecutar `scan`, ver entidades ordenadas por `distanceMeters`, y modificar alerta solo cuando corresponda.

---

## Solución implementada
Decisiones principales
- Se agregó `ScanCommand` como derivada de `Command`.
- `execute()` toma `nearbyEntities()` (punteros observadores), copia solo el vector de punteros y ordena con `std::sort` de forma ascendente por distancia.
- Si detecta al menos una entidad `Hostile`, llama `model.incrementAlert("Hostiles detectados durante escaneo de zona.")`.
- El nivel de alerta estará en función de la cantidad de `Hostile` detectados.

Archivos o módulos clave
- `src/controller/scanCommand.hpp`
- `src/controller/scanCommand.cpp`
- `src/controller/commandRegistry.cpp`

---

## Cambios incluidos
- Se creó `ScanCommand` (header + implementación).
- Se registró `scan` en `buildRegistry()`.
- Se incorporó `scanCommand.cpp` al target `cyberpunk_lib`.
- Se incorporó `scanCommand_test.cpp` al target `unit_tests`.
- Se agregaron los 5 tests de aceptación para `ScanCommand` más 3 test para probar la sincronía del comando `scan` con el estado de alerta.

---

## Consideraciones técnicas C++
- [ ] No aplica
- [x] Se respetó const-correctness
- [x] Se evitó copiar objetos innecesariamente
- [x] Se usó RAII / manejo seguro de recursos
- [x] Se revisó ownership de memoria/punteros
- [x] Se evitó código duplicado
- [x] Se consideró complejidad temporal/espacial
- [x] Se mantuvo compatibilidad con la arquitectura existente

Detalle adicional
- Complejidad temporal de scan: O(n log n) debido al ordenamiento de entidades con std::sort. Espacial: O(n) por la copia del vector de punteros observadores. 

---

## Cómo probar este cambio
Correr el juego y escribir el comando "scan" en consola. 

### Resultado esperado
- `ScanCommandTest` pasa 8/8 test.
- El output de `scan` usa formato compacto por entidad, por ejemplo:
  - `[HOSTIL] Corporativo Militech - 25 m`. En futuras versiones, se podría implementar un output con arte ASCII.
- En zona vacía imprime `Sin entidades detectadas.` y no modifica alerta.

---

## Evidencia
- [ ] No aplica
- [ ] Capturas adjuntas
- [ ] Logs adjuntos
- [x] Output de consola adjunto
- [ ] Video/GIF adjunto

Evidencia
---------------------------------------------------------------------------------------------------------------
 - [Runner_001 | 250cr | BAJA]> help

╔══════════════════════════════════════╗
║     CYBERPUNK CBA 2077 — COMANDOS    ║
╚══════════════════════════════════════╝

  [ __internal ]
    __unknown       

  [ mundo ]
    scan            Escanea entidades cercanas en la zona.

  [ runner ]
    status          Muestra el estado del runner.

  [ sistema ]
    help            Muestra los comandos disponibles.

  Total: 4 comandos disponibles.

[Runner_001 | 250cr | BAJA]> scan
Escaneo de zona: Sector 7
[NEUTRAL] Vendedor ambulante - 35 m
[AMIGABLE] Netrunner aliado - 80 m
[HOSTIL] Corporativo Militech - 120 m
---------------------------------------------------------------------------------------------------------------

---

## Riesgos / impacto
Impacto esperado:

- [x] Cambio aislado
- [ ] Puede afectar otros módulos
- [x] Puede modificar comportamiento existente
- [ ] Puede introducir regresiones si no se valida correctamente

Módulos potencialmente afectados
- `controller/commandRegistry`
- Flujo de comandos mostrados por `help`

Breaking changes:

- [x] No
- [ ] Sí

Si la respuesta es sí, explicar
- N/A

---

## Testing realizado
- [x] Compila correctamente en mi entorno
- [x] Se agregaron o actualizaron tests unitarios
- [x] Los tests existentes siguen pasando
- [x] Se hizo validación manual
- [x] Se probaron casos borde
- [ ] No aplica agregar tests

Detalle
- `ScanCommandTest` cubre:
  - orden ascendente por distancia
  - incremento de alerta con hostiles
  - zona vacía sin cambios en modelo
  - solo amigables sin incremento
  - presencia de disposiciones en output
  - eleva la alerta al nivel adecuado según la cantidad de hostiles
  - el nivel de alerta llega a su máximo ante la presencia de 4 hostiles o más.
  - el nivel de alerta se mantiene igual si la cantidad de hostiles disminuye (transitorio, ya que no existe aún un  método para disminuir el estado de alerta)
- La suite completa no queda 100% verde por un test previo ajeno a esta PR (`TimeOfDayTest.MinutesUntilNextTurn_Midnight`) en `types_test.cpp`.

---

## Checklist del autor
- [x] Linkeé la issue / tarea correspondiente
- [x] Me asigné esta PR
- [x] El cambio tiene un objetivo claro y acotado
- [x] No mezclé cambios no relacionados
- [x] Revisé mi propio diff antes de pedir review
- [x] El código compila
- [x] Actualicé tests si correspondía
- [x] Actualicé documentación si correspondía
- [x] No dejé código muerto, prints temporales o comentarios innecesarios
- [x] Los nombres de variables, funciones y clases son claros
- [x] La solución respeta la modularidad del proyecto

---

## Checklist de review
- [x] Review técnica realizada
- [x] Approval de Tester
- [x] Approval de Team Lead

Reviewer(s):

- Tester: Luis Palacio - Equipo Now Hiring
- Team Lead: Luis Palacio - Equipo Now Hiring

---

## Notas para el reviewer
Orden sugerido de revisión:
1. `src/controller/scanCommand.hpp` y `src/controller/scanCommand.cpp`
2. `src/controller/commandRegistry.cpp`
3. `tests/controller/scanCommand_test.cpp`

Se han detectado 4 warnings en el archivo `bench_gamemodel.cpp` que alteran el score de la revisión automática. No han sido modificados en este sprint ya que escapa al scope del mismo.

Puntos donde quiero feedback
- Comprobar la sincronía del nivel de amenaza con la cantidad de hostiles al utilizar el comando `scan`. 

Dudas abiertas
- Sería mejor reemplazar el método `incrementAlertLevel()` por uno llamado `setAlertLevel()` para contemplar los casos donde la amenaza disminuye, ya que el método presente sólo permite aumentarla.
