### PR TITLE
Feature/command credits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(CYBERPUNK_BUILD_TESTS)
     tests/common/types_test.cpp
     tests/model/gameModel_test.cpp
     tests/controller/commandRegistry_test.cpp
+          tests/controller/commandCredits_test.cpp
   )
 
   target_include_directories(unit_tests PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(cyberpunk_lib STATIC
   src/controller/helpCommand.cpp
   src/controller/statusCommand.cpp
   src/controller/unknownCommand.cpp
+  src/controller/commandCredits.cpp
 )
 
 target_include_directories(cyberpunk_lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(CYBERPUNK_BUILD_TESTS)
     tests/common/types_test.cpp
     tests/model/gameModel_test.cpp
     tests/controller/commandRegistry_test.cpp
-          tests/controller/commandCredits_test.cpp
+    tests/controller/commandCredits_test.cpp
   )
 
   target_include_directories(unit_tests PRIVATE

--- a/include/controller/commandCredits.hpp
+++ b/include/controller/commandCredits.hpp
@@ -5,9 +5,9 @@
  * @file commandCredits.hpp
  * @brief Define el comando encargado de mostrar la información del equipo de desarrollo y las métricas de la sesión.
  */
-#include "controller/command.hpp" 
-#include <vector>
+#include "controller/command.hpp"
 #include <string>
+#include <vector>
 
 namespace CyberpunkCba
 {
@@ -17,7 +17,8 @@ namespace CyberpunkCba
      * @struct TeamMember
      * @brief Representa a un miembro del equipo de desarrollo.
      */
-    struct TeamMember {
+    struct TeamMember
+    {
         std::string name;
         std::string role;
     };
@@ -26,12 +27,12 @@ namespace CyberpunkCba
      * @class CommandCredits
      * @brief Comando que muestra los créditos del equipo de desarrollo y el estado actual del juego.
      */
-    class CommandCredits final : public Command 
+    class CommandCredits final : public Command
     {
     public:
         /**
          * @brief Constructor de la clase CommandCredits.
-         * Inicializa el comando almacenando la lista de los miembros del equipo 
+         * Inicializa el comando almacenando la lista de los miembros del equipo
          * y el nombre del grupo de desarrollo.
          * @param team Vector que contiene a los miembros del equipo
          * @param teamName Nombre asignado al equipo de desarrollo
@@ -43,7 +44,7 @@ namespace CyberpunkCba
          */
         ~CommandCredits() override = default;
 
-    private: 
+    private:
         // Métodos con override heredan de la clase Command
         void execute(GameModel& model) override;
         std::string name() const override;
@@ -53,6 +54,6 @@ namespace CyberpunkCba
         std::vector<TeamMember> m_team;
         std::string m_teamName;
     };
-}
+} // namespace CyberpunkCba
 
 #endif

--- a/include/controller/commandCredits.hpp
+++ b/include/controller/commandCredits.hpp
@@ -1,0 +1,58 @@
+#ifndef _CREDITS_COMMAND_HPP
+#define _CREDITS_COMMAND_HPP
+
+/**
+ * @file commandCredits.hpp
+ * @brief Define el comando encargado de mostrar la información del equipo de desarrollo y las métricas de la sesión.
+ */
+#include "controller/command.hpp" 
+#include <vector>
+#include <string>
+
+namespace CyberpunkCba
+{
+    class GameModel;
+
+    /**
+     * @struct TeamMember
+     * @brief Representa a un miembro del equipo de desarrollo.
+     */
+    struct TeamMember {
+        std::string name;
+        std::string role;
+    };
+
+    /**
+     * @class CommandCredits
+     * @brief Comando que muestra los créditos del equipo de desarrollo y el estado actual del juego.
+     */
+    class CommandCredits final : public Command 
+    {
+    public:
+        /**
+         * @brief Constructor de la clase CommandCredits.
+         * Inicializa el comando almacenando la lista de los miembros del equipo 
+         * y el nombre del grupo de desarrollo.
+         * @param team Vector que contiene a los miembros del equipo
+         * @param teamName Nombre asignado al equipo de desarrollo
+         */
+        CommandCredits(std::vector<TeamMember> team, std::string teamName);
+
+        /**
+         * @brief Destructor por defecto.
+         */
+        ~CommandCredits() override = default;
+
+    private: 
+        // Métodos con override heredan de la clase Command
+        void execute(GameModel& model) override;
+        std::string name() const override;
+        std::string description() const override;
+        std::string category() const override;
+
+        std::vector<TeamMember> m_team;
+        std::string m_teamName;
+    };
+}
+
+#endif

--- a/include/controller/commandCredits.hpp
+++ b/include/controller/commandCredits.hpp
@@ -1,5 +1,5 @@
-#ifndef _CREDITS_COMMAND_HPP
-#define _CREDITS_COMMAND_HPP
+#ifndef COMMAND_CREDITS_HPP
+#define COMMAND_CREDITS_HPP
 
 /**
  * @file commandCredits.hpp

--- a/src/controller/commandCredits.cpp
+++ b/src/controller/commandCredits.cpp
@@ -8,6 +8,17 @@
 #include <iomanip>
 #include <algorithm>
 
+/**
+ * @file commandCredits.cpp
+ * @brief Implementación de CommandCredits.
+ *
+ * @details
+ * Muestra el equipo de desarrollo con padding dinámico de columnas
+ * y métricas de sesión leídas desde GameModel.
+ *
+ */
+
+
 namespace CyberpunkCba
 {
     CommandCredits::CommandCredits(std::vector<TeamMember> team, std::string teamName)

--- a/src/controller/commandCredits.cpp
+++ b/src/controller/commandCredits.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file commandCredits.cpp
+ * @brief Implementación de la clase CommandCredits.
+ */
+#include "controller/commandCredits.hpp"
+#include "model/gameModel.hpp" 
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+
+namespace CyberpunkCba
+{
+    CommandCredits::CommandCredits(std::vector<TeamMember> team, std::string teamName)
+        : m_team(std::move(team)), m_teamName(std::move(teamName)) 
+    {
+    }
+
+    void CommandCredits::execute(GameModel& model) 
+    {
+        if (m_team.empty()) {
+            std::cout << "ERROR: No hay miembros en el equipo de creditos.\n";
+            return;
+        }
+        if (m_team.size() < 4) {
+            std::cout << "ADVERTENCIA: Equipo Incompleto.\n";
+        } else {
+            std::cout << "=== EQUIPO DE DESARROLLO: " << m_teamName << " ===\n";
+        }
+        size_t maxRoleWidth = 0;
+        for (const auto& member : m_team) {
+            maxRoleWidth = std::max(maxRoleWidth, member.role.length());
+        }
+        for (const auto& member : m_team) {
+            std::cout << std::left << std::setw(static_cast<int>(maxRoleWidth)) 
+                      << member.role << " | " << member.name << "\n";
+        }
+        std::cout << "\n--- ESTADISTICAS DE LA SESION ---\n";
+        std::cout << "Sprints Finalizados: " << model.sprintsCompleted() << "\n";
+        std::cout << "PRs Mergeados:      " << model.mergedPRs() << "\n";
+    }
+
+    std::string CommandCredits::name() const 
+    { 
+        return "credits"; 
+    }
+
+    std::string CommandCredits::description() const 
+    { 
+        return "Muestra los creditos del equipo y metricas de desarrollo."; 
+    }
+
+    std::string CommandCredits::category() const 
+    { 
+        return "sistema"; 
+    }
+}

--- a/src/controller/commandCredits.cpp
+++ b/src/controller/commandCredits.cpp
@@ -1,9 +1,9 @@
 
 #include "controller/commandCredits.hpp"
-#include "model/gameModel.hpp" 
-#include <iostream>
-#include <iomanip>
+#include "model/gameModel.hpp"
 #include <algorithm>
+#include <iomanip>
+#include <iostream>
 
 /**
  * @file commandCredits.cpp
@@ -15,50 +15,56 @@
  *
  */
 
-
 namespace CyberpunkCba
 {
     CommandCredits::CommandCredits(std::vector<TeamMember> team, std::string teamName)
-        : m_team(std::move(team)), m_teamName(std::move(teamName)) 
+        : m_team(std::move(team))
+        , m_teamName(std::move(teamName))
     {
     }
 
-    void CommandCredits::execute(GameModel& model) 
+    void CommandCredits::execute(GameModel& model)
     {
-        if (m_team.empty()) {
+        if (m_team.empty())
+        {
             std::cout << "ERROR: No hay miembros en el equipo de creditos.\n";
             return;
         }
-        if (m_team.size() < 4) {
+        if (m_team.size() < 4)
+        {
             std::cout << "ADVERTENCIA: Equipo Incompleto.\n";
-        } else {
+        }
+        else
+        {
             std::cout << "=== EQUIPO DE DESARROLLO: " << m_teamName << " ===\n";
         }
         size_t maxRoleWidth = 0;
-        for (const auto& member : m_team) {
+        for (const auto& member : m_team)
+        {
             maxRoleWidth = std::max(maxRoleWidth, member.role.length());
         }
-        for (const auto& member : m_team) {
-            std::cout << std::left << std::setw(static_cast<int>(maxRoleWidth)) 
-                      << member.role << " | " << member.name << "\n";
+        for (const auto& member : m_team)
+        {
+            std::cout << std::left << std::setw(static_cast<int>(maxRoleWidth)) << member.role << " | " << member.name
+                      << "\n";
         }
         std::cout << "\n--- ESTADISTICAS DE LA SESION ---\n";
         std::cout << "Comandos ejecutados: " << model.commandCount() << "\n";
         std::cout << "HP actual:           " << model.hp() << "\n";
     }
 
-    std::string CommandCredits::name() const 
-    { 
-        return "credits"; 
+    std::string CommandCredits::name() const
+    {
+        return "credits";
     }
 
-    std::string CommandCredits::description() const 
-    { 
-        return "Muestra los creditos del equipo y metricas de desarrollo."; 
+    std::string CommandCredits::description() const
+    {
+        return "Muestra los creditos del equipo y metricas de desarrollo.";
     }
 
-    std::string CommandCredits::category() const 
-    { 
-        return "sistema"; 
+    std::string CommandCredits::category() const
+    {
+        return "sistema";
     }
-}
+} // namespace CyberpunkCba

--- a/src/controller/commandCredits.cpp
+++ b/src/controller/commandCredits.cpp
@@ -1,7 +1,4 @@
-/**
- * @file commandCredits.cpp
- * @brief Implementación de la clase CommandCredits.
- */
+
 #include "controller/commandCredits.hpp"
 #include "model/gameModel.hpp" 
 #include <iostream>
@@ -46,8 +43,8 @@ namespace CyberpunkCba
                       << member.role << " | " << member.name << "\n";
         }
         std::cout << "\n--- ESTADISTICAS DE LA SESION ---\n";
-        std::cout << "Sprints Finalizados: " << model.sprintsCompleted() << "\n";
-        std::cout << "PRs Mergeados:      " << model.mergedPRs() << "\n";
+        std::cout << "Comandos ejecutados: " << model.commandCount() << "\n";
+        std::cout << "HP actual:           " << model.hp() << "\n";
     }
 
     std::string CommandCredits::name() const 

--- a/src/controller/commandCredits.cpp
+++ b/src/controller/commandCredits.cpp
@@ -43,14 +43,21 @@ namespace CyberpunkCba
         {
             maxRoleWidth = std::max(maxRoleWidth, member.role.length());
         }
+        std::ios::fmtflags oldFlags = std::cout.flags();
+        char oldFill = std::cout.fill();
+
         for (const auto& member : m_team)
         {
             std::cout << std::left << std::setw(static_cast<int>(maxRoleWidth)) << member.role << " | " << member.name
                       << "\n";
         }
-        std::cout << "\n--- ESTADISTICAS DE LA SESION ---\n";
-        std::cout << "Comandos ejecutados: " << model.commandCount() << "\n";
-        std::cout << "HP actual:           " << model.hp() << "\n";
+
+        std::cout.flags(oldFlags);
+        std::cout.fill(oldFill);
+
+        std::cout << "\n--- METRICAS DE LA SESION ---\n";
+        std::cout << "Sprints completados: " << model.sprintsCompleted() << "\n";
+        std::cout << "PRs fusionados:      " << model.mergedPRs() << "\n";
     }
 
     std::string CommandCredits::name() const

--- a/src/controller/commandRegistry.cpp
+++ b/src/controller/commandRegistry.cpp
@@ -8,6 +8,7 @@
 // ============================================================
 // ZONA DE EQUIPOS — agregar un #include por equipo
 // ============================================================
+#include "controller/commandCredits.hpp"
 
 // ============================================================
 // FIN ZONA DE EQUIPOS
@@ -113,7 +114,8 @@ namespace CyberpunkCba
         // ZONA DE EQUIPOS — agregar una línea por equipo
         // Formato: registry.add(std::make_unique<TuComandoCommand>());
         // ============================================================
-
+        std::vector<CyberpunkCba::TeamMember> team = {{"Ana", "Dev"}, {"Juan", "Software Engineer"}, {"Lucas", "QA"}};
+        registry.add(std::make_unique<CyberpunkCba::CommandCredits>(team, "DreamTeam"));
         // ============================================================
         // FIN ZONA DE EQUIPOS
         // ============================================================

--- a/src/model/gameModel.cpp
+++ b/src/model/gameModel.cpp
@@ -30,6 +30,8 @@ namespace CyberpunkCba
         , m_hackCost {HACK_COST}
         , m_commandCount {0}
         , m_sessionStart {std::chrono::steady_clock::now()}
+        , m_sprintsCompleted {0}
+        , m_mergedPRs {0}
         , m_running {true}
     {
         assert(!m_playerName.empty());
@@ -235,6 +237,16 @@ namespace CyberpunkCba
     int GameModel::commandCount() const noexcept
     {
         return m_commandCount;
+    }
+
+    int GameModel::sprintsCompleted() const noexcept
+    {
+        return m_sprintsCompleted;
+    }
+
+    int GameModel::mergedPRs() const noexcept
+    {
+        return m_mergedPRs;
     }
 
     std::chrono::seconds GameModel::sessionDuration() const noexcept

--- a/tests/controller/commandCredits_test.cpp
+++ b/tests/controller/commandCredits_test.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+#include "controller/commandCredits.hpp"
+#include "model/gameModel.hpp"
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+using namespace CyberpunkCba;
+
+class CommandCreditsTest : public ::testing::Test {
+protected:
+    GameModel model{"RunnerTest"};
+    std::stringstream buffer;
+    std::streambuf* oldCout;
+
+    void SetUp() override {
+        oldCout = std::cout.rdbuf(buffer.rdbuf());
+    }
+
+    void TearDown() override {
+        std::cout.rdbuf(oldCout);
+    }
+};
+
+TEST_F(CommandCreditsTest, VectorVacioNoCrashea) {
+    std::vector<TeamMember> emptyTeam;
+    CommandCredits cmd(emptyTeam, "TeamTest");
+    Command& baseCmd = cmd;
+    ASSERT_NO_THROW(baseCmd.execute(model));
+    std::string output = buffer.str();
+    EXPECT_TRUE(output.find("Error") != std::string::npos || output.find("No hay miembros") != std::string::npos);
+}
+
+TEST_F(CommandCreditsTest, EquipoIncompletoMuestraAdvertencia) {
+    std::vector<TeamMember> team = {{"Juan", "Dev"}};
+    CommandCredits cmd(team, "TeamTest");
+    Command& baseCmd = cmd;
+    baseCmd.execute(model);
+    EXPECT_TRUE(buffer.str().find("ADVERTENCIA") != std::string::npos);
+}
+
+TEST_F(CommandCreditsTest, HappyPathEquipoCompleto) {
+    std::vector<TeamMember> team = {
+        {"A", "Dev"}, {"B", "QA"}, {"C", "PM"}, {"D", "UI"}
+    };
+    CommandCredits cmd(team, "DreamTeam");
+    Command& baseCmd = cmd;
+    baseCmd.execute(model);
+    std::string output = buffer.str();
+    EXPECT_TRUE(output.find("=== EQUIPO DE DESARROLLO: DreamTeam ===") != std::string::npos);
+    EXPECT_TRUE(output.find("ADVERTENCIA") == std::string::npos);
+}
+
+TEST_F(CommandCreditsTest, PaddingCalculadoCorrectamente) {
+    std::vector<TeamMember> team = {
+        {"Ana", "Dev"},
+        {"Carlos", "Senior Software Engineer"}
+    };
+    CommandCredits cmd(team, "TeamTest");
+    Command& baseCmd = cmd;
+    baseCmd.execute(model);
+    std::string output = buffer.str();
+    std::string lineaEsperada = "Dev";
+    lineaEsperada.append(21, ' ');
+    lineaEsperada += " | Ana";
+    EXPECT_TRUE(output.find(lineaEsperada) != std::string::npos);
+}
+
+TEST_F(CommandCreditsTest, GameModelNoEsModificado) {
+    int hpAntes = model.hp();
+    int creditsAntes = model.credits();
+    int alertAntes = static_cast<int>(model.alertLevel());
+    std::vector<TeamMember> team = {{"A", "B"}, {"C", "D"}, {"E", "F"}, {"G", "H"}};
+    CommandCredits cmd(team, "TeamTest");
+    Command& baseCmd = cmd;
+    baseCmd.execute(model);
+    EXPECT_EQ(model.hp(), hpAntes);
+    EXPECT_EQ(model.credits(), creditsAntes);
+    EXPECT_EQ(static_cast<int>(model.alertLevel()), alertAntes);
+}

--- a/tests/controller/commandCredits_test.cpp
+++ b/tests/controller/commandCredits_test.cpp
@@ -1,29 +1,33 @@
-#include <gtest/gtest.h>
 #include "controller/commandCredits.hpp"
 #include "model/gameModel.hpp"
-#include <vector>
-#include <string>
-#include <sstream>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace CyberpunkCba;
 
-class CommandCreditsTest : public ::testing::Test {
+class CommandCreditsTest : public ::testing::Test
+{
 protected:
-    GameModel model{"RunnerTest"};
+    GameModel model {"RunnerTest"};
     std::stringstream buffer;
     std::streambuf* oldCout;
 
-    void SetUp() override {
+    void SetUp() override
+    {
         oldCout = std::cout.rdbuf(buffer.rdbuf());
     }
 
-    void TearDown() override {
+    void TearDown() override
+    {
         std::cout.rdbuf(oldCout);
     }
 };
 
-TEST_F(CommandCreditsTest, VectorVacioNoCrashea) {
+TEST_F(CommandCreditsTest, VectorVacioNoCrashea)
+{
     std::vector<TeamMember> emptyTeam;
     CommandCredits cmd(emptyTeam, "TeamTest");
     Command& baseCmd = cmd;
@@ -32,7 +36,8 @@ TEST_F(CommandCreditsTest, VectorVacioNoCrashea) {
     EXPECT_TRUE(output.find("Error") != std::string::npos || output.find("No hay miembros") != std::string::npos);
 }
 
-TEST_F(CommandCreditsTest, EquipoIncompletoMuestraAdvertencia) {
+TEST_F(CommandCreditsTest, EquipoIncompletoMuestraAdvertencia)
+{
     std::vector<TeamMember> team = {{"Juan", "Dev"}};
     CommandCredits cmd(team, "TeamTest");
     Command& baseCmd = cmd;
@@ -40,10 +45,9 @@ TEST_F(CommandCreditsTest, EquipoIncompletoMuestraAdvertencia) {
     EXPECT_TRUE(buffer.str().find("ADVERTENCIA") != std::string::npos);
 }
 
-TEST_F(CommandCreditsTest, HappyPathEquipoCompleto) {
-    std::vector<TeamMember> team = {
-        {"A", "Dev"}, {"B", "QA"}, {"C", "PM"}, {"D", "UI"}
-    };
+TEST_F(CommandCreditsTest, HappyPathEquipoCompleto)
+{
+    std::vector<TeamMember> team = {{"A", "Dev"}, {"B", "QA"}, {"C", "PM"}, {"D", "UI"}};
     CommandCredits cmd(team, "DreamTeam");
     Command& baseCmd = cmd;
     baseCmd.execute(model);
@@ -52,11 +56,9 @@ TEST_F(CommandCreditsTest, HappyPathEquipoCompleto) {
     EXPECT_TRUE(output.find("ADVERTENCIA") == std::string::npos);
 }
 
-TEST_F(CommandCreditsTest, PaddingCalculadoCorrectamente) {
-    std::vector<TeamMember> team = {
-        {"Ana", "Dev"},
-        {"Carlos", "Senior Software Engineer"}
-    };
+TEST_F(CommandCreditsTest, PaddingCalculadoCorrectamente)
+{
+    std::vector<TeamMember> team = {{"Ana", "Dev"}, {"Carlos", "Senior Software Engineer"}};
     CommandCredits cmd(team, "TeamTest");
     Command& baseCmd = cmd;
     baseCmd.execute(model);
@@ -67,7 +69,8 @@ TEST_F(CommandCreditsTest, PaddingCalculadoCorrectamente) {
     EXPECT_TRUE(output.find(lineaEsperada) != std::string::npos);
 }
 
-TEST_F(CommandCreditsTest, GameModelNoEsModificado) {
+TEST_F(CommandCreditsTest, GameModelNoEsModificado)
+{
     int hpAntes = model.hp();
     int creditsAntes = model.credits();
     int alertAntes = static_cast<int>(model.alertLevel());

--- a/tests/controller/commandCredits_test.cpp
+++ b/tests/controller/commandCredits_test.cpp
@@ -58,13 +58,30 @@ TEST_F(CommandCreditsTest, HappyPathEquipoCompleto)
 
 TEST_F(CommandCreditsTest, PaddingCalculadoCorrectamente)
 {
-    std::vector<TeamMember> team = {{"Ana", "Dev"}, {"Carlos", "Senior Software Engineer"}};
+    std::vector<TeamMember> team = {{"Ana", "Dev"}, {"Carlos", "Software Engineer"}};
     CommandCredits cmd(team, "TeamTest");
     Command& baseCmd = cmd;
     baseCmd.execute(model);
     std::string output = buffer.str();
-    std::string lineaEsperada = "Dev";
-    lineaEsperada.append(21, ' ');
+
+    // Calculamos el padding esperado en función del rol más largo
+    std::string rolReferencia = "Dev";
+    size_t maxRoleLength = 0;
+    for (const auto& miembro : team)
+    {
+        if (miembro.role.length() > maxRoleLength)
+        {
+            maxRoleLength = miembro.role.length();
+        }
+    }
+    size_t padding = 0;
+    if (maxRoleLength > rolReferencia.length())
+    {
+        padding = maxRoleLength - rolReferencia.length();
+    }
+
+    std::string lineaEsperada = rolReferencia;
+    lineaEsperada.append(padding, ' ');
     lineaEsperada += " | Ana";
     EXPECT_TRUE(output.find(lineaEsperada) != std::string::npos);
 }


### PR DESCRIPTION
## Tipo de cambio
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] Performance
- [ ] Build / CI
- [ ] Chore

## Issue / tarea relacionada
- Closes #82

## Resumen del cambio
Implementa CommandCredits que muestra el equipo de desarrollo con padding dinámico de columnas y métricas de sesión leídas desde GameModel.

## Problema / motivación
Contexto
Faltaba el comando credits que debía mostrar los integrantes del equipo.

Problema observado
No existía la clase CommandCredits ni cobertura de tests para la misma.

Resultado esperado
Al ejecutar credits se muestra el equipo con los roles alineados dinámicamente y un mensaje de advertencia si el equipo tiene menos de 4 miembros.

## Solución implementada
Decisiones principales
- No se modifica GameModel.
- Execute calcula el ancho máximo iterando los roles antes de imprimir, sin padding hardcodeado.
- Se manejan dos estados: equipo completo (4+ miembros) y equipo incompleto (menos de 4).

Archivos o módulos clave
- include/controller/commandCredits.hpp
- src/controller/commandCredits.cpp
- tests/controller/commandCredits_test.cpp
- CMakeLists.txt

## Cambios incluidos
- Se agregó clase CommandCredits con struct TeamMember
- Se agregaron 5 tests que comprueban: vector vacío no crashea, equipo incompleto muestra advertencia, happy path equipo completo, padding calculado correctamente, GameModel no es modificado

## Cómo probar este cambio
1. cd build
2. cmake --build .
3. ctest --output-on-failure

### Resultado esperado
Los 5 tests de CommandCreditsTest pasan correctamente.

## Evidencia
- [x] Output de consola adjunto

Evidencia
![WhatsApp Image 2026-03-22 at 00 13 57](https://github.com/user-attachments/assets/4f8fb97d-2d6f-428b-a4d6-332bf6b1047e)



## Riesgos / impacto
Impacto esperado:
- [x] Cambio aislado

Módulos potencialmente afectados
- Sin impacto en otros módulos

Breaking changes:
- [x] No

## Testing realizado
- [x] Compila correctamente en mi entorno
- [x] Se agregaron o actualizaron tests unitarios
- [x] Los tests existentes siguen pasando
- [x] Se probaron casos borde

Detalle
El test MinutesUntilNextTurn_Midnight del archivo types_test.cpp no pasa, pero no corresponde al alcance de este PR.

## Checklist del autor
- [x] Linkeé la issue / tarea correspondiente
- [x] Me asigné esta PR
- [x] El cambio tiene un objetivo claro y acotado
- [x] No mezclé cambios no relacionados
- [x] El código compila
- [x] Actualicé tests si correspondía

## Notas para el reviewer
Orden sugerido de revisión:
1. include/controller/commandCredits.hpp
2. src/controller/commandCredits.cpp
3. tests/controller/commandCredits_test.cpp

Puntos donde quiero feedback
- Feedback en los tests