### PR TITLE
Feature/fileio entity serialization cpp20 compat

### DIFF
--- a/include/common/fileIO.hpp
+++ b/include/common/fileIO.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 /**
- * @file FileIO.hpp
+ * @file fileIO.hpp
  * @brief Structs de dominio  y funciones de lectura/escritura de archivos.
  *
  * @details
@@ -89,13 +89,13 @@ namespace CyberpunkCba
      *
      * @invariant !type.empty()
      * @invariant amount >= 0
-     * @invariant !concept.empty()
+     * @invariant !description.empty()
      */
     struct Transaction
     {
-        std::string type;    ///< "ingreso" o "gasto"
-        int amount;          ///< Monto en créditos. >= 0.
-        std::string concept; ///< Descripción de la transacción.
+        std::string type;        ///< "ingreso" o "gasto"
+        int amount;              ///< Monto en créditos. >= 0.
+        std::string description; ///< Descripción de la transacción.
     };
 
     /**

--- a/src/common/fileIO.cpp
+++ b/src/common/fileIO.cpp
@@ -181,6 +181,18 @@ namespace CyberpunkCba
                 return false;
             }
 
+            // Convierte EntityDisposition a string canónico persistible.
+            [[nodiscard]] const char* dispositionToString(const EntityDisposition disposition) noexcept
+            {
+                switch (disposition)
+                {
+                    case EntityDisposition::Friendly: return "Friendly";
+                    case EntityDisposition::Neutral: return "Neutral";
+                    case EntityDisposition::Hostile: return "Hostile";
+                }
+                return "Neutral";
+            }
+
             // Convierte string a Faction. Retorna false si no es válido.
             bool toFaction(const std::string& s, Faction& out)
             {
@@ -497,9 +509,9 @@ namespace CyberpunkCba
                 }
 
                 std::istringstream ss {line};
-                std::string type, amountStr, concept;
+                std::string type, amountStr, description;
 
-                if (!nextField(ss, type) || !nextField(ss, amountStr) || !nextField(ss, concept))
+                if (!nextField(ss, type) || !nextField(ss, amountStr) || !nextField(ss, description))
                 {
                     warnInvalidLine(path, lineNumber, line);
                     continue;
@@ -512,7 +524,7 @@ namespace CyberpunkCba
                     continue;
                 }
 
-                result.push_back({type, amount, concept});
+                result.push_back({type, amount, description});
             }
             return result;
         }
@@ -638,17 +650,17 @@ namespace CyberpunkCba
             assert(!entry.name.empty());
             std::ofstream file;
             openForAppend(path, file);
-            file << entry.name << SEPARATOR << entityDispositionToString(entry.disposition) << SEPARATOR
+            file << entry.name << SEPARATOR << dispositionToString(entry.disposition) << SEPARATOR
                  << entry.distanceMeters << "\n";
         }
 
         void appendTransaction(const Transaction& entry, const std::filesystem::path& path)
         {
             assert(entry.amount >= 0);
-            assert(!entry.concept.empty());
+            assert(!entry.description.empty());
             std::ofstream file;
             openForAppend(path, file);
-            file << entry.type << SEPARATOR << entry.amount << SEPARATOR << entry.concept << "\n";
+            file << entry.type << SEPARATOR << entry.amount << SEPARATOR << entry.description << "\n";
         }
 
         void appendPurchase(const PurchaseEntry& entry, const std::filesystem::path& path)

--- a/tests/common/fileIO_test.cpp
+++ b/tests/common/fileIO_test.cpp
@@ -255,6 +255,18 @@ TEST_F(TempDir, LoadEntities_NegativeDistance_LineIgnored)
     EXPECT_EQ(loadEntities(tmp("entities.txt")).size(), 1u);
 }
 
+TEST_F(TempDir, LoadEntities_UnknownDisposition_LineIgnored)
+{
+    write("entities.txt", "Entidad|Unknown|10\nBuena|Neutral|10\n");
+
+    const auto result {loadEntities(tmp("entities.txt"))};
+
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].name, "Buena");
+    EXPECT_EQ(result[0].disposition, EntityDisposition::Neutral);
+    EXPECT_EQ(result[0].distanceMeters, 10);
+}
+
 // =============================================================================
 // loadReputation
 // =============================================================================
@@ -310,7 +322,7 @@ TEST_F(TempDir, LoadWallet_ValidLines_ParsedCorrectly)
     ASSERT_EQ(result.size(), 2u);
     EXPECT_EQ(result[0].type, "ingreso");
     EXPECT_EQ(result[0].amount, 500);
-    EXPECT_EQ(result[0].concept, "misión completada");
+    EXPECT_EQ(result[0].description, "misión completada");
     EXPECT_EQ(result[1].type, "gasto");
     EXPECT_EQ(result[1].amount, 80);
 }
@@ -455,11 +467,21 @@ TEST_F(TempDir, AppendEntity_RoundTrip)
 {
     const auto path {tmp("entities.txt")};
     appendEntity({"Corporativo", EntityDisposition::Hostile, 120}, path);
+    appendEntity({"Aliado", EntityDisposition::Friendly, 80}, path);
+    appendEntity({"Civil", EntityDisposition::Neutral, 25}, path);
+
     const auto result {loadEntities(path)};
-    ASSERT_EQ(result.size(), 1u);
+
+    ASSERT_EQ(result.size(), 3u);
     EXPECT_EQ(result[0].name, "Corporativo");
     EXPECT_EQ(result[0].disposition, EntityDisposition::Hostile);
     EXPECT_EQ(result[0].distanceMeters, 120);
+    EXPECT_EQ(result[1].name, "Aliado");
+    EXPECT_EQ(result[1].disposition, EntityDisposition::Friendly);
+    EXPECT_EQ(result[1].distanceMeters, 80);
+    EXPECT_EQ(result[2].name, "Civil");
+    EXPECT_EQ(result[2].disposition, EntityDisposition::Neutral);
+    EXPECT_EQ(result[2].distanceMeters, 25);
 }
 
 // =============================================================================
@@ -474,7 +496,7 @@ TEST_F(TempDir, AppendTransaction_RoundTrip)
     ASSERT_EQ(result.size(), 1u);
     EXPECT_EQ(result[0].type, "gasto");
     EXPECT_EQ(result[0].amount, 80);
-    EXPECT_EQ(result[0].concept, "deck de hackeo");
+    EXPECT_EQ(result[0].description, "deck de hackeo");
 }
 
 // =============================================================================


### PR DESCRIPTION
# Pull Request — CyberCba2077

## Tipo de cambio
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] Performance
- [ ] Build / CI
- [ ] Chore

---

## Issue / tarea relacionada
- Closes #184
- Related #157

---

## Resumen del cambio
Este PR:
- alinea la serialización de `EntityDisposition` en `appendEntity()` con el formato canónico que consume `loadEntities()`
- corrige el identificador `concept` en `Transaction` para evitar el warning/error de compatibilidad C++20
- actualiza y amplía tests de `FileIO` para cubrir el nuevo contrato

---

## Problema / motivación
Contexto
- `FileIO` debía garantizar round-trip entre escritura y lectura de `entities.txt` y compilar sin warnings bloqueantes.

Problema observado
- `appendEntity()` escribía valores no compatibles con `loadEntities()`.
- `Transaction::concept` disparaba `-Wc++20-compat` con `-Werror`.

Resultado esperado
- round-trip correcto para `Friendly/Neutral/Hostile`
- build sin error por `concept`
- tests actualizados al nuevo contrato

---

## Solución implementada
Decisiones principales
- `appendEntity()` ahora serializa disposición en formato canónico persistible (`Friendly|Neutral|Hostile`).
- Se renombró `Transaction::concept` a `Transaction::description` en API y uso interno.
- Se mantuvo el comportamiento de lectura: disposición desconocida sigue siendo línea inválida ignorada.

Archivos o módulos clave
- `src/common/fileIO.cpp`
- `include/common/fileIO.hpp`
- `tests/common/fileIO_test.cpp`

---

## Cambios incluidos
- corrección de serialización de `EntityDisposition` en `appendEntity()`
- rename `Transaction::concept` -> `Transaction::description`
- actualización de assertions en tests de wallet/transacciones
- cobertura consolidada en `AppendEntity_RoundTrip` para Hostile/Friendly/Neutral
- nuevo test explícito para disposición desconocida ignorada

---

## Consideraciones técnicas C++
- [ ] No aplica
- [x] Se respetó const-correctness
- [x] Se evitó copiar objetos innecesariamente
- [x] Se usó RAII / manejo seguro de recursos
- [x] Se revisó ownership de memoria/punteros
- [x] Se evitó código duplicado
- [x] Se consideró complejidad temporal/espacial
- [x] Se mantuvo compatibilidad con la arquitectura existente

Detalle adicional
- No se modificó ownership ni contratos fuera del módulo `FileIO`.

---

## Cómo probar este cambio
1. `cmake --build cmake-build-debug --target unit_tests`
2. `./cmake-build-debug/unit_tests --gtest_filter=TempDir.LoadEntities_ValidLines_ParsedCorrectly:TempDir.LoadEntities_UnknownDisposition_LineIgnored:TempDir.AppendEntity_RoundTrip:TempDir.LoadWallet_ValidLines_ParsedCorrectly:TempDir.AppendTransaction_RoundTrip`
3. (Opcional) `./cmake-build-debug/unit_tests --gtest_filter=TempDir.*`

### Resultado esperado
- Los tests del filtro anterior deben pasar en verde.
- `appendEntity()` y `loadEntities()` deben hacer round-trip para las 3 disposiciones canónicas.
- No debe aparecer error de compilación por `Transaction::concept`.

---

## Evidencia
- [x] No aplica
- [ ] Capturas adjuntas
- [ ] Logs adjuntos
- [ ] Output de consola adjunto
- [ ] Video/GIF adjunto

---

## Riesgos / impacto
Impacto esperado:
- [x] Cambio aislado
- [ ] Puede afectar otros módulos
- [x] Puede modificar comportamiento existente
- [ ] Puede introducir regresiones si no se valida correctamente

Módulos potencialmente afectados
- `FileIO` (entidades y wallet)
- tests unitarios de `FileIO`
- consumidores de `Transaction` (por rename de campo)

Breaking changes:
- [ ] No
- [x] Sí

Si la respuesta es sí, explicar
- Cambio de nombre de campo en `Transaction`: `concept` -> `description`.

---

## Testing realizado
- [x] Compila correctamente en mi entorno
- [x] Se agregaron o actualizaron tests unitarios
- [ ] Los tests existentes siguen pasando
- [x] Se hizo validación manual
- [x] Se probaron casos borde
- [ ] No aplica agregar tests

Detalle
- La suite completa tiene fallos preexistentes no relacionados; los tests del alcance de esta issue están en verde.

---

## Checklist del autor
- [x] Linkeé la issue / tarea correspondiente
- [x] Me asigné esta PR
- [x] El cambio tiene un objetivo claro y acotado
- [x] No mezclé cambios no relacionados
- [x] Revisé mi propio diff antes de pedir review
- [x] El código compila
- [x] Actualicé tests si correspondía
- [x] Actualicé documentación si correspondía
- [x] No dejé código muerto, prints temporales o comentarios innecesarios
- [x] Los nombres de variables, funciones y clases son claros
- [x] La solución respeta la modularidad del proyecto

---

## Checklist de review
- [x] Review técnica realizada
- [x] Approval de Tester
- [x] Approval de Team Lead

Reviewer(s):
- Tester: Luis Palacio
- Team Lead: Luis Palacio

---

## Notas para el reviewer
Orden sugerido de revisión:
1. `src/common/fileIO.cpp` (serialización y wallet)
2. `include/common/fileIO.hpp` (rename de `Transaction`)
3. `tests/common/fileIO_test.cpp` (cobertura actualizada)

Puntos donde quiero feedback
- Confirmación de que el rename `concept -> description` es aceptable como contrato del módulo.
- Confirmación de criterios de aceptación para tests del alcance.

Dudas abiertas
- Detecté una incompatibilidad similar en inventory: `saveInventory()` serializa usando `itemTypeToString(...)` (labels de salida), mientras `loadInventory()` parsea valores canónicos (Weapon|Consumable|Value|Tech). Esto puede romper el round-trip `saveInventory() -> loadInventory()` y se refleja en `TempDir.SaveInventory_OverwritesExisting`. No se incluyó en esta PR por scope. Se debería abrir issue separada para alinear serialización/parsing de ItemType, ya que este error impide avanzar con la issue #155 .